### PR TITLE
Loading config files with real path to allow relative paths

### DIFF
--- a/lib/MikroConfig.ts
+++ b/lib/MikroConfig.ts
@@ -1,5 +1,5 @@
 import { get, set, has, merge } from 'lodash';
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, realpathSync } from 'fs';
 
 const CONFIG = {};
 
@@ -46,7 +46,7 @@ export class MikroConfig {
       }
 
       if (existsSync(options)) {
-        options = require(options);
+        options = require(realpathSync(options));
       } else if (optional) {
         options = {};
       } else {


### PR DESCRIPTION
This allows to specify relative NODE_CONFIG_DIR in NPM scripts. Solves NX that runs from root and runs applications in apps folder.

```
  "scripts": {
    "serve:api": "cross-env NODE_ENV=local NODE_CONFIG_DIR=./apps/api/config nx serve api",
  }
```